### PR TITLE
Add option to expose LUIS entities for use in questions

### DIFF
--- a/src/luis-middleware.js
+++ b/src/luis-middleware.js
@@ -4,7 +4,8 @@ module.exports = {
     middleware: {
         receive: receive,
         hereIntent: hereIntent,
-        hereAction: hereAction
+        hereAction: hereAction,
+        getEntity: getEntity,
     }
 };
 
@@ -97,4 +98,9 @@ function hereAction(tests, message) {
         }
     }
     return false;
+}
+
+function getEntity({ entities = [] }, ...types) {
+    const entity = entities.find(entity => types.includes(entity.type));
+    return entity && (entity.resolution.value || entity.resolution.values);
 }

--- a/src/luis-middleware.js
+++ b/src/luis-middleware.js
@@ -20,6 +20,7 @@ function receive(options) {
     }
     var minThreshold = options.minThreshold || 0.1;
     var captureThreshold = options.captureThreshold || 0.7;
+    var alwaysIncludeEntities = options.alwaysIncludeEntities || false;
     return function (bot, message, next) {
         // We will only process the text and either there's no topIntent
         // or the score for the topIntent is below the captureThreshold.
@@ -32,6 +33,9 @@ function receive(options) {
 
                         var result = JSON.parse(body);
 
+                        if (alwaysIncludeEntities) {
+                            message.entities = result.entities || [];
+                        }
 						if (result.topScoringIntent) {
 							// API v2.0
 							message.topIntent = result.topScoringIntent;


### PR DESCRIPTION
With the release of Botkit 4.8, bot developers now have access to the full `message` object inside of dialogs. This allows for the opportunity to use LUIS entities not just to trigger new dialogs, but also as a means of interpreting a user's response to a prompt.

For example:
```
    dialog.addQuestion('Enter a date', async (rawInput, convo, bot, message) => {
        const dateEntity = message.entities.find(entity => entity.type === 'builtin.datetimeV2.date');
        const date = new Date(dateEntity.resolution.value);
        doStuffWith(date);
        ...
}
```

The PR exposes an option `alwaysIncludeEntities` that, when true, will attach entities from the LUIS service to the message.

I've also added a helper function that finds an expected entity type. It can be used like this:
```
    dialog.addQuestion('Please enter the price', async (rawValue, convo, bot, message) => {
        const number = luis.middleware.getEntity(message, 'builtin.number', 'builtin.currency') || rawValue;
        doStuffWith(number);
        ...
}
```